### PR TITLE
fix: Address PubCom revisions

### DIFF
--- a/bib/ref.bib
+++ b/bib/ref.bib
@@ -26,12 +26,12 @@
     note = "\url{https://cds.cern.ch/record/2749422/}"
 }
 
-@article{ATLAS:2020pnm,
+@Booklet{ATLAS:2020pnm,
     author = "{ATLAS Collaboration}",
     title = "{ATLAS HL-LHC Computing Conceptual Design Report}",
-    reportNumber = "CERN-LHCC-2020-015, LHCC-G-178",
+    howpublished = "CERN-LHCC-2020-015; LHCC-G-178",
+    url = "https://cds.cern.ch/record/2729668",
     year = "2020",
-    note = "\url{https://cds.cern.ch/record/2729668}"
 }
 
 # https://iris-hep.org/docs/acknowledgements
@@ -122,14 +122,12 @@
 
 ATLAS Collaboration, ATLAS Software and Computing HL-LHC Roadmap,
 CERN-LHCC-2022-005, 2022, url: http://cds.cern.ch/record/2802918.
-@misc{CERN-LHCC-2022-005,
-      author        = "{ATLAS Collaboration}",
-      title         = "{ATLAS Software and Computing HL-LHC Roadmap}",
-      institution   = "CERN",
-      reportNumber  = "CERN-LHCC-2022-005, LHCC-G-182",
-      address       = "Geneva",
-      year          = "2022",
-      url           = "https://cds.cern.ch/record/2802918",
+@Booklet{CERN-LHCC-2022-005,
+    author = "{ATLAS Collaboration}",
+    title = "{ATLAS Software and Computing HL-LHC Roadmap}",
+    howpublished = "CERN-LHCC-2022-005; LHCC-G-182",
+    url = "https://cds.cern.ch/record/2802918",
+    year = "2022",
 }
 
 % PHYSLITE CHEP 2023 proceedings

--- a/chep_2024_proceedings.tex
+++ b/chep_2024_proceedings.tex
@@ -6,7 +6,7 @@
 \begin{document}
 
 % CHEP proceedings are due to the conference Jan 31, 2025, have an 4-8 pages for parallel oral contributions
-\linenumbers
+% \linenumbers
 %
 \title{Building a Columnar Analysis Demonstrator for ATLAS PHYSLITE Open Data using the Python Ecosystem}
 


### PR DESCRIPTION
Resolves #12

* Apply revisions to address PubCom comments.
   - c.f. https://cds.cern.ch/record/2919696/comments?ln=en#C329091
* Add report numbers to references.
* Turn off line numbers.